### PR TITLE
Use public interface of Boost.Iterator

### DIFF
--- a/include/boost/token_iterator.hpp
+++ b/include/boost/token_iterator.hpp
@@ -18,11 +18,11 @@
 #ifndef BOOST_TOKENIZER_POLICY_JRB070303_HPP_
 #define BOOST_TOKENIZER_POLICY_JRB070303_HPP_
 
-#include<boost/assert.hpp>
-#include<boost/iterator/iterator_adaptor.hpp>
-#include<boost/iterator/detail/minimum_category.hpp>
-#include<boost/token_functions.hpp>
-#include<utility>
+#include <boost/assert.hpp>
+#include <boost/iterator/iterator_adaptor.hpp>
+#include <boost/iterator/minimum_category.hpp>
+#include <boost/token_functions.hpp>
+#include <utility>
 
 namespace boost
 {
@@ -31,7 +31,7 @@ namespace boost
       : public iterator_facade<
             token_iterator<TokenizerFunc, Iterator, Type>
           , Type
-          , typename detail::minimum_category<
+          , typename iterators::minimum_category<
                 forward_traversal_tag
               , typename iterator_traversal<Iterator>::type
             >::type


### PR DESCRIPTION
The pull request accommodates changes to Boost.Iterator and switch to the public interface instead of implementation details.
