### PR TITLE
Changes for Embarcadero C++ clang-based compilers, targeting Boost 1.74. Change __BORLANDC__ to BOOST_BORLANDC, which is defined in Boost conf…

### DIFF
--- a/test/simple_example_5.cpp
+++ b/test/simple_example_5.cpp
@@ -11,7 +11,7 @@
 #include<boost/token_iterator.hpp>
 #include<string>
 
-#ifdef __BORLANDC__
+#ifdef BOOST_BORLANDC
 // compiler bug fix:
 template class boost::token_iterator_generator<boost::offset_separator>::type;
 #endif


### PR DESCRIPTION
…ig for the Embarcadero non-clang-based compilers.